### PR TITLE
Adapt froot-1 to be packaged for buildroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,29 @@
+prefix=/usr/local
+exec_prefix=$(prefix)
+bindir=$(exec_prefix)/bin
+datarootdir=$(prefix)/share
+datadir=$(datarootdir)
+CC = gcc
 CFLAGS = -g
 
 all: froot1 bin2rom rom2bin
 
 froot1: fake6502.o froot1.o
-	gcc ${CFLAGS} -o froot1 froot1.o fake6502.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o froot1 froot1.o fake6502.o
 
 bin2rom: bin2rom.o
-	gcc ${CFLAGS} -o bin2rom bin2rom.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o bin2rom bin2rom.o
 
 rom2bin: rom2bin.o
-	gcc ${CFLAGS} -o rom2bin rom2bin.o
+	$(CC) $(CFLAGS) $(LDFLAGS) -o rom2bin rom2bin.o
 
 install:
-	cp froot1 bin2rom rom2bin /usr/local/bin
-	mkdir -p /usr/local/share/froot-1
-	cp monitor.rom wozbasic.rom wozaci.rom /usr/local/share/froot-1
+	cp froot1 bin2rom rom2bin $(bindir)
+	mkdir -p $(datadir)/froot-1
+	cp monitor.rom wozbasic.rom wozaci.rom $(datadir)/froot-1
 
 clean:
 	rm -f froot1 bin2rom rom2bin *.o
 
 .c.o:
-	gcc ${CFLAGS} -c $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -c $<

--- a/froot1.c
+++ b/froot1.c
@@ -350,10 +350,22 @@ char line[1024];
 int load_mem(char *filename, bool read_only) {
     FILE *in;
 
+    const char* const DATADIRS[] = {
+        "/usr/local/share/froot-1",
+        "/usr/share/froot-1"
+    };
+    const int DATADIRS_COUNT = 2;
+
     // Open the input file
     if ((in = fopen(filename, "r")) == NULL) {
-        snprintf(line, sizeof(line)-1, "/usr/local/share/froot-1/%s", filename);
-        if ((in = fopen(line, "r")) == NULL) {
+        for (int i=0; i<DATADIRS_COUNT; i++) {
+            snprintf(line, sizeof(line)-1, "%s/%s", DATADIRS[i], filename);
+            if ((in = fopen(line, "r")) != NULL) {
+                break;
+            }
+        }
+
+        if (in == NULL) {
             fprintf(stderr, "Can't open file %s\n", filename);
             return 0;
         }


### PR DESCRIPTION
Hi Mark,

I hope you find these changes useful.

I would like to use your froot-1 to recreate an Apple 1 replica on a Raspberry Pi.

I intend to use [buildroot](https://buildroot.org/) and, in this PR, I am proposing some changes that would make it easier for me to package it for buildroot.

Let me know what you think.

Kind Regards
binary-sequence