### PR TITLE
Reassign CTRL-L to CLS and CTRL-O to open/load file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+bin2rom
+froot1
+rom2bin

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ automatically converts lowercase keystrokes to upper-case.
 ## Special Keys
 There are a few special keys recognized by the emulator:\
 Control-R  Reset button\
+Control-L Clear the screen\
 Control-C  Exit the emulator\
-Control-L  Load a text file as input to the Apple-1\
+Control-O  Open/Load a text file as input to the Apple-1\
 
 The Control-L option is useful if you have a Basic program as a
 text file and you want to load it. Copy&paste doesn't work very well

--- a/froot1.c
+++ b/froot1.c
@@ -9,10 +9,15 @@
 #include <ctype.h>
 #include <unistd.h>
 
-#define LF  0x0A
-#define CR  0x0D
-#define SP  0x20
-#define DEL 0x7F
+#define CTRL_C  3   // SIGINT
+#define CTRL_D  4   // DBG
+#define CTRL_L  12  // Load file
+#define CTRL_R  18  // RST
+#define BS  0x08  // Backspace
+#define LF  0x0A  // Linefeed
+#define CR  0x0D  // Carriage return
+#define SP  0x20  // Space
+#define DEL 0x7F  // Delete
 
 uint8_t ram[65536];
 bool rom[65536];
@@ -702,27 +707,27 @@ void handle_kb() {
 
     ch = getchar();
 
-    if (ch == 18) {                 // Ctrl-R
+    if (ch == CTRL_R) {
         printf("RESET\n");
         reset6502();
-    } else if (ch == 4) {   // Ctrl-D
+    } else if (ch == CTRL_D) {
         debugging = true;
         printf("Debugging mode.\n");
-    } else if (ch == 3) {           // Ctrl-C
+    } else if (ch == CTRL_C) {
         reset_term();
         exit(0);
     } else if (char_pending || reading_file) {
         // If the last character hasn't been processed, push this one back
         ungetc(ch, stdin);
-    } else if (ch == 10) {
+    } else if (ch == LF) {
         // Convert a newline to carriage-return
-        char_pending = 13;
-    } else if (ch == 8 || ch == 0x7f) {
+        char_pending = CR;
+    } else if (ch == BS || ch == DEL) {
         // Backspace or delete were originally converted to 3f (?) because that's what
         // the Apple-1 uses for delete. I patched monitor.rom so that 8 is a backspace
         // instead of 3F
-        char_pending = 8;
-    } else if (ch == 12) {  // Ctrl-L
+        char_pending = BS;
+    } else if (ch == CTRL_L) {
         printf("Load from file: ");
         reset_term();
         fgets(input_line, sizeof(input_line)-1, stdin);

--- a/froot1.c
+++ b/froot1.c
@@ -708,7 +708,6 @@ void handle_kb() {
     ch = getchar();
 
     if (ch == CTRL_R) {
-        printf("RESET\n");
         reset6502();
     } else if (ch == CTRL_D) {
         debugging = true;

--- a/froot1.c
+++ b/froot1.c
@@ -11,7 +11,8 @@
 
 #define CTRL_C  3   // SIGINT
 #define CTRL_D  4   // DBG
-#define CTRL_L  12  // Load file
+#define CTRL_L  12  // CLS
+#define CTRL_O  15  // Open (load) file
 #define CTRL_R  18  // RST
 #define BS  0x08  // Backspace
 #define LF  0x0A  // Linefeed
@@ -727,6 +728,8 @@ void handle_kb() {
         // instead of 3F
         char_pending = BS;
     } else if (ch == CTRL_L) {
+        system("clear");
+    } else if (ch == CTRL_O) {
         printf("Load from file: ");
         reset_term();
         fgets(input_line, sizeof(input_line)-1, stdin);


### PR DESCRIPTION
```
The original Apple-1 accepted a "clear" key.
In ASCII control codes, CTRL-L means "clear screen".

- Re-assign CTRL-L to Apple-1's clear key
- Assign CTRL-O to froot-1's open.
```

Hi Mark,

I hope you find this change useful.

Cheers