### PR TITLE
Fix and improve debugging for relative addresses

### DIFF
--- a/froot1.c
+++ b/froot1.c
@@ -1258,7 +1258,7 @@ void disassemble(uint16_t from, uint16_t to) {
                 printf(" #$%02x\n", ram[from+1]);
                 break;
             case REL:
-                printf(" $%04x\n", from+2+(char)ram[from+1]);
+                printf(" %d  ; $%04x\n", (int8_t)ram[from+1], from+inst_size+(int8_t)ram[from+1]);
                 break;
             case NONE:
                 printf("\n");


### PR DESCRIPTION
Sample program to reproduce:
`0: A9 FF 30 FC`

```
                            * = $0000
0000   A9 FF      LOOP      LDA #$FF
0002   30 FC                BMI LOOP
                            .END
```

1. Type in program
2. Start debugger (CTRL-D)
3. See disassembled output for `30 FC`

Before this fix (wrong)
```
pc = 0002  a=ff  x=00  y=01  sp=fd  status=N      C
0002: 30 fc     bmi $0100
```

After this fix (right)
```
pc = 0002  a=ff  x=00  y=01  sp=fd  status=N      C
0002: 30 fc     bmi -4  ; $0000
```